### PR TITLE
Update OFL.txt

### DIFF
--- a/OFL.txt
+++ b/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2020 Hahmlet Minjoo Ham & Mark Frömberg (https://github.com/hyper-type/hahmlet)
+Copyright 2020 The Hahmlet Projec Authors (https://github.com/hyper-type/hahmlet)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
This updates the copyright notice to the GF standard, and will resolve a Font Bakery FAIL result (and also resolve the non-ascii character FAIL) 

The notice in the font files needs to be updated to match